### PR TITLE
Don't cut the line before the dot, it's incompatible with Ruby < 1.9

### DIFF
--- a/spec/sftp_spec.rb
+++ b/spec/sftp_spec.rb
@@ -82,8 +82,7 @@ describe CarrierWave::Storage::SFTP do
     end
 
     it "returns the size of the file" do
-      @sftp.should_receive(:stat!).with('/home/test_user/public_html/uploads/test.jpg')
-          .and_return(Struct.new(:size).new(14))
+      @sftp.should_receive(:stat!).with('/home/test_user/public_html/uploads/test.jpg').and_return(Struct.new(:size).new(14))
       @stored.size.should == 14
     end
 


### PR DESCRIPTION
The title is pretty self explanatory ;)

I'm using Ruby 1.8.7 and I couldn't run the tests without this small fix
