### PR TITLE
Accept carrierwave ~> 0.6

### DIFF
--- a/carrerwave-ftp.gemspec
+++ b/carrerwave-ftp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", ["~> 0.6.2"]
+  s.add_dependency "carrierwave", ["~> 0.6", ">= 0.6.2"]
   s.add_dependency "net-sftp", ["~> 2.0.5"]
   s.add_development_dependency "rspec", ["~> 2.6"]
   s.add_development_dependency "rake", ["~> 0.9"]


### PR DESCRIPTION
I wanted to use it with CarrierWave 0.7, as mentioned in https://github.com/luan/carrierwave-ftp/issues/2

i've not yet tried a real app with this setup, but all the tests pass.
