### PR TITLE
Changing the dependency version of carrierwave (current is 0.8)

### DIFF
--- a/carrerwave-ftp.gemspec
+++ b/carrerwave-ftp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", ["~> 0.6.2"]
+  s.add_dependency "carrierwave", [">= 0.6.2"]
   s.add_dependency "net-sftp", ["~> 2.0.5"]
   s.add_development_dependency "rspec", ["~> 2.6"]
   s.add_development_dependency "rake", ["~> 0.9"]


### PR DESCRIPTION
I just changed the dependency version of carrierwave. People can't install carrierwave-ftp because it is need carrierwave 0.6 and now carrierwave is 0.8. I run tests and all seems to work well and I am using it without any problems.
