### PR TITLE
Add passive mode config option to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ CarrierWave.configure do |config|
   config.ftp_passwd = "secret"
   config.ftp_folder = "/public_html/uploads"
   config.ftp_url = "http://example.com/uploads"
+  config.passive = false # false by default
 end
 ```
 


### PR DESCRIPTION
Currently, there is an option to configure FTP passive mode. Unfortunately, it's not stated in the README.md.
This commit adds it to readme so that new users don't have to check gem sources to configure passive mode.
