### PR TITLE
Bump net-sftp version

### DIFF
--- a/carrerwave-ftp.gemspec
+++ b/carrerwave-ftp.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency "carrierwave", [">= 0.6.2"]
-  s.add_dependency "net-sftp", ["~> 2.0.5"]
+  s.add_dependency "net-sftp", ["~> 2.1.2"]
   s.add_development_dependency "rspec", ["~> 2.6"]
   s.add_development_dependency "rake", ["~> 0.9"]
 end


### PR DESCRIPTION
All tests pass using 2.1 version of net-sftp.
