### PR TITLE
Fix monkey-patched NET::SFTP::Session#mkdir_p! to work with absolute paths.

### DIFF
--- a/lib/carrierwave/storage/ftp/ex_sftp.rb
+++ b/lib/carrierwave/storage/ftp/ex_sftp.rb
@@ -2,17 +2,12 @@ require 'net/sftp'
 
 class Net::SFTP::Session
   def mkdir_p!(dir)
-    parts = dir.split("/")
-    growing_path = ""
+    parts = dir.split(File::SEPARATOR)
+    growing_parts = []
     for part in parts
-      next if part == ""
-      if growing_path == ""
-        growing_path = part
-      else
-        growing_path = File.join(growing_path, part)
-      end
+      growing_parts.push(part)
       begin
-        mkdir!(growing_path)
+        mkdir!(File.join(growing_parts))
       rescue
       end
     end


### PR DESCRIPTION
This is a fix for issue #17.  The tests mock the sftp session, so no tests.  Manual testing works for me with both relative and absolute paths.
