### PR TITLE
fix ftp_port

### DIFF
--- a/lib/carrierwave/storage/ftp.rb
+++ b/lib/carrierwave/storage/ftp.rb
@@ -92,10 +92,17 @@ module CarrierWave
         end
 
         def connection
-          ftp = ExFTP.open(@uploader.ftp_host, @uploader.ftp_user, @uploader.ftp_passwd, @uploader.ftp_port)
-          ftp.passive = @uploader.ftp_passive
-          yield ftp
-          ftp.close
+          ftp = ExFTP.new
+          ftp.connect(@uploader.ftp_host, @uploader.ftp_port)
+          
+          begin
+            ftp.passive = @uploader.ftp_passive
+            ftp.login(@uploader.ftp_user, @uploader.ftp_passwd)
+          
+            yield ftp
+          ensure
+            ftp.close
+          end
         end
       end
     end

--- a/spec/ftp_spec.rb
+++ b/spec/ftp_spec.rb
@@ -31,7 +31,9 @@ describe CarrierWave::Storage::FTP do
       21
     ]
 
-    Net::FTP.should_receive(:open).with(*ftp_params).and_return(ftp)
+    Net::FTP.should_receive(:new).and_return(ftp)
+    ftp.should_receive(:connect).with('ftp.testcarrierwave.dev', 21)
+    ftp.should_receive(:login).with('test_user', 'test_passwd')
     ftp.should_receive(:passive=).with(true)
     ftp.should_receive(:mkdir_p).with('~/public_html/uploads')
     ftp.should_receive(:chdir).with('~/public_html/uploads')
@@ -43,7 +45,9 @@ describe CarrierWave::Storage::FTP do
   describe 'after upload' do
     before do
       ftp = double(:ftp_connection)
-      Net::FTP.stub(:open).and_return(ftp)
+      Net::FTP.stub(:new).and_return(ftp)
+      ftp.stub(:connect)
+      ftp.stub(:login)
       ftp.stub(:passive=)
       ftp.stub(:mkdir_p)
       ftp.stub(:chdir)
@@ -64,7 +68,9 @@ describe CarrierWave::Storage::FTP do
   describe 'other operations' do
     before do
       @ftp = double(:ftp_connection)
-      Net::FTP.stub(:open).and_return(@ftp)
+      Net::FTP.stub(:new).and_return(@ftp)
+      @ftp.stub(:connect)
+      @ftp.stub(:login)
       @ftp.stub(:passive=)
       @ftp.stub(:mkdir_p)
       @ftp.stub(:chdir)


### PR DESCRIPTION
Hi,

This fixes the ftp storage adapter to correctly pass the ftp_port to Net::FTP.  Currently it passes the ftp_port as the last arg to open, which is supposed to be acct:

http://ruby-doc.org/stdlib-2.0.0/libdoc/net/ftp/rdoc/Net/FTP.html#method-c-open

I've fixed this to use connect.  see #19 for the test
