### PR TITLE
use quit instead close

### DIFF
--- a/lib/carrierwave/storage/ftp.rb
+++ b/lib/carrierwave/storage/ftp.rb
@@ -94,14 +94,14 @@ module CarrierWave
         def connection
           ftp = ExFTP.new
           ftp.connect(@uploader.ftp_host, @uploader.ftp_port)
-          
+
           begin
             ftp.passive = @uploader.ftp_passive
             ftp.login(@uploader.ftp_user, @uploader.ftp_passwd)
-          
+
             yield ftp
           ensure
-            ftp.close
+            ftp.quit
           end
         end
       end

--- a/spec/ftp_spec.rb
+++ b/spec/ftp_spec.rb
@@ -38,7 +38,7 @@ describe CarrierWave::Storage::FTP do
     ftp.should_receive(:mkdir_p).with('~/public_html/uploads')
     ftp.should_receive(:chdir).with('~/public_html/uploads')
     ftp.should_receive(:put).with(@file.path, 'test.jpg')
-    ftp.should_receive(:close)
+    ftp.should_receive(:quit)
     @stored = @storage.store!(@file)
   end
 
@@ -52,7 +52,7 @@ describe CarrierWave::Storage::FTP do
       ftp.stub(:mkdir_p)
       ftp.stub(:chdir)
       ftp.stub(:put)
-      ftp.stub(:close)
+      ftp.stub(:quit)
       @stored = @storage.store!(@file)
     end
 
@@ -75,7 +75,7 @@ describe CarrierWave::Storage::FTP do
       @ftp.stub(:mkdir_p)
       @ftp.stub(:chdir)
       @ftp.stub(:put)
-      @ftp.stub(:close)
+      @ftp.stub(:quit)
       @stored = @storage.store!(@file)
     end
 


### PR DESCRIPTION
It seems, it is more reliable to use quit instead of close. 
close - socket level command. 
quit - protocol level command. 

It is impossible to recognize that socket is closed intentionally or due to network problems. 
Some servers check if socket is closed in the middle of uploading, this file is considered corrupted and removed. To avoid it, it should use quit command. 
