### PR TITLE
Download files using SFTP/FTP instead of HTTP

### DIFF
--- a/lib/carrierwave/storage/sftp.rb
+++ b/lib/carrierwave/storage/sftp.rb
@@ -39,7 +39,10 @@ module CarrierWave
         def to_file
           temp_file = Tempfile.new(filename)
           temp_file.binmode
-          temp_file.write file.body
+          connection do |sftp|
+            sftp.download!(full_path, temp_file)
+          end
+          temp_file.rewind
           temp_file
         end
 
@@ -58,7 +61,10 @@ module CarrierWave
         end
 
         def read
-          file.body
+          file = to_file
+          content = file.read
+          file.close
+          content
         end
 
         def content_type
@@ -80,15 +86,6 @@ module CarrierWave
 
         def full_path
           "#{@uploader.sftp_folder}/#{path}"
-        end
-
-        def file
-          require 'net/http'
-          url = URI.parse(self.url)
-          req = Net::HTTP::Get.new(url.path)
-          Net::HTTP.start(url.host, url.port) do |http|
-            http.request(req)
-          end
         end
 
         def connection

--- a/spec/ftp_spec.rb
+++ b/spec/ftp_spec.rb
@@ -96,12 +96,14 @@ describe CarrierWave::Storage::FTP do
     end
 
     it "returns to_file" do
-      @stored.should_receive(:file).and_return(Struct.new(:body).new('some content'))
+      @ftp.should_receive(:chdir).with('~/public_html/uploads')
+      @ftp.should_receive(:get).with('test.jpg', nil).and_yield('some content')
       @stored.to_file.size.should == 'some content'.length
     end
 
     it "returns the content of the file" do
-      @stored.should_receive(:file).and_return(Struct.new(:body).new('some content'))
+      @ftp.should_receive(:chdir).with('~/public_html/uploads')
+      @ftp.should_receive(:get).with('test.jpg', nil).and_yield('some content')
       @stored.read.should == 'some content'
     end
 

--- a/spec/sftp_spec.rb
+++ b/spec/sftp_spec.rb
@@ -44,16 +44,16 @@ describe CarrierWave::Storage::SFTP do
 
   describe 'after upload' do
     before do
-      sftp = double(:sftp_connection)
-      Net::SFTP.stub(:start).and_return(sftp)
-      sftp.stub(:mkdir_p!)
-      sftp.stub(:upload!)
-      sftp.stub(:close_channel)
+      @sftp = double(:sftp_connection)
+      Net::SFTP.stub(:start).and_return(@sftp)
+      @sftp.stub(:mkdir_p!)
+      @sftp.stub(:upload!)
+      @sftp.stub(:close_channel)
       @stored = @storage.store!(@file)
     end
 
-    it "should use the calculated URL when retrieving a file" do
-      @stored.should_receive(:url).and_return('http://example.com/')
+    it "should use the ftp when retrieving a file" do
+      @sftp.should_receive(:download!).with(@stored.send(:full_path), kind_of(Tempfile))
       @stored.read
     end
 
@@ -92,13 +92,13 @@ describe CarrierWave::Storage::SFTP do
     end
 
     it "returns to_file" do
-      @stored.should_receive(:file).and_return(Struct.new(:body).new('some content'))
-      @stored.to_file.size.should == 'some content'.length
+      @sftp.should_receive(:download!).with(@stored.send(:full_path), kind_of(Tempfile))
+      @stored.to_file.size.should == 0
     end
 
     it "returns the content of the file" do
-      @stored.should_receive(:file).and_return(Struct.new(:body).new('some content'))
-      @stored.read.should == 'some content'
+      @sftp.should_receive(:download!).with(@stored.send(:full_path), kind_of(Tempfile))
+      @stored.read.should == ''
     end
 
     it "returns the content_type of the file" do


### PR DESCRIPTION
This PR fixes issue #24.  It should allow for the configured URL to be used solely for advertising to users' web browsers and similar.
