### PR TITLE
fix IOError: closed stream on rewind after sftp download

### DIFF
--- a/lib/carrierwave/storage/sftp.rb
+++ b/lib/carrierwave/storage/sftp.rb
@@ -42,6 +42,7 @@ module CarrierWave
           connection do |sftp|
             sftp.download!(full_path, temp_file)
           end
+          temp_file.open
           temp_file.rewind
           temp_file
         end


### PR DESCRIPTION
Hi there! Thanks for great job and useful gem.

I faced an error `IOError: closed stream` while downloading a file from SFTP to Tempfile. I'm using `net-sftp 2.1.2` and `Ruby 2.3.1`. The error produced because of close at the end of download: https://github.com/net-ssh/net-sftp/blob/master/lib/net/sftp/operations/download.rb#L331

I'm not sure if it is correct, but my fix is to call `open` anyway after a download, so Tempfile remains opened before `rewind` call.