### PR TITLE
Adds config to control use of CHMOD

### DIFF
--- a/lib/carrierwave/storage/ftp.rb
+++ b/lib/carrierwave/storage/ftp.rb
@@ -27,7 +27,9 @@ module CarrierWave
             ftp.mkdir_p(::File.dirname "#{@uploader.ftp_folder}/#{path}")
             ftp.chdir(::File.dirname "#{@uploader.ftp_folder}/#{path}")
             ftp.put(file.path, filename)
-            ftp.sendcmd("SITE CHMOD #{@uploader.permissions.to_s(8)} #{@uploader.ftp_folder}/#{path}")
+            if @uploader.ftp_chmod
+              ftp.sendcmd("SITE CHMOD #{@uploader.permissions.to_s(8)} #{@uploader.ftp_folder}/#{path}")
+            end
           end
         end
 
@@ -126,6 +128,7 @@ class CarrierWave::Uploader::Base
   add_config :ftp_url
   add_config :ftp_passive
   add_config :ftp_tls
+  add_config :ftp_chmod
 
   configure do |config|
     config.storage_engines[:ftp] = "CarrierWave::Storage::FTP"
@@ -137,5 +140,6 @@ class CarrierWave::Uploader::Base
     config.ftp_url = "http://localhost"
     config.ftp_passive = false
     config.ftp_tls = false
+    config.ftp_chmod = true
   end
 end

--- a/spec/ftp_spec.rb
+++ b/spec/ftp_spec.rb
@@ -7,7 +7,7 @@ end
 
 describe CarrierWave::Storage::FTP do
   before do
-    CarrierWave.configure do |config|
+    FtpUploader.configure do |config|
       config.reset_config
       config.ftp_host = 'ftp.testcarrierwave.dev'
       config.ftp_user = 'test_user'
@@ -15,6 +15,7 @@ describe CarrierWave::Storage::FTP do
       config.ftp_folder = '~/public_html'
       config.ftp_url = 'http://testcarrierwave.dev'
       config.ftp_passive = true
+      config.ftp_chmod = true
     end
 
     @file = CarrierWave::SanitizedFile.new(file_path('test.jpg'))
@@ -41,6 +42,34 @@ describe CarrierWave::Storage::FTP do
     ftp.should_receive(:sendcmd).with("SITE CHMOD 644 ~/public_html/uploads/test.jpg")
     ftp.should_receive(:quit)
     @stored = @storage.store!(@file)
+  end
+
+  describe 'when CHMOD is disabled' do
+    before do
+      FtpUploader.configure do |config|
+        config.ftp_chmod = false
+      end
+    end
+
+    it "opens/closes an ftp connection to the given host" do
+      ftp = double(:ftp_connection)
+      ftp_params = [
+        'ftp.testcarrierwave.dev',
+        'test_user',
+        'test_passwd',
+        21
+      ]
+
+      Net::FTP.should_receive(:new).and_return(ftp)
+      ftp.should_receive(:connect).with('ftp.testcarrierwave.dev', 21)
+      ftp.should_receive(:login).with('test_user', 'test_passwd')
+      ftp.should_receive(:passive=).with(true)
+      ftp.should_receive(:mkdir_p).with('~/public_html/uploads')
+      ftp.should_receive(:chdir).with('~/public_html/uploads')
+      ftp.should_receive(:put).with(@file.path, 'test.jpg')
+      ftp.should_receive(:quit)
+      @stored = @storage.store!(@file)
+    end
   end
 
   describe 'after upload' do

--- a/spec/ftp_tls_spec.rb
+++ b/spec/ftp_tls_spec.rb
@@ -7,7 +7,7 @@ end
 
 describe CarrierWave::Storage::FTP do
   before do
-    CarrierWave.configure do |config|
+    FtpTlsUploader.configure do |config|
       config.reset_config
       config.ftp_host = 'ftp.testcarrierwave.dev'
       config.ftp_user = 'test_user'
@@ -16,6 +16,7 @@ describe CarrierWave::Storage::FTP do
       config.ftp_url = 'http://testcarrierwave.dev'
       config.ftp_passive = true
       config.ftp_tls = true
+      config.ftp_chmod = true
     end
 
     @file = CarrierWave::SanitizedFile.new(file_path('test.jpg'))
@@ -36,5 +37,27 @@ describe CarrierWave::Storage::FTP do
     ftp.should_receive(:put).with(@file.path, 'test.jpg')
     ftp.should_receive(:quit)
     @stored = @storage.store!(@file)
+  end
+
+  describe 'when CHMOD is disabled' do
+    before do
+      FtpTlsUploader.configure do |config|
+        config.ftp_chmod = false
+      end
+    end
+
+    it "opens/closes a secure ftp connection to the given host" do
+      ftp = double(:ftp_connection)
+      Net::FTP.should_receive(:new).and_return(ftp)
+      ftp.should_receive(:ssl_context=)
+      ftp.should_receive(:connect).with('ftp.testcarrierwave.dev', 21)
+      ftp.should_receive(:login).with('test_user', 'test_passwd')
+      ftp.should_receive(:passive=).with(true)
+      ftp.should_receive(:mkdir_p).with('~/public_html/uploads')
+      ftp.should_receive(:chdir).with('~/public_html/uploads')
+      ftp.should_receive(:put).with(@file.path, 'test.jpg')
+      ftp.should_receive(:quit)
+      @stored = @storage.store!(@file)
+    end
   end
 end


### PR DESCRIPTION
I've been getting permission denied errors when the `CHMOD` command is run. I've tried figuring out why, but I'm stumped. 

I'd rather trust that the server is configured to upload the files correctly, so I added an option to bypass the `CHMOD` call.