### PR TITLE
Fixes undefined method exception when querying content_type

### DIFF
--- a/lib/carrierwave/storage/ftp.rb
+++ b/lib/carrierwave/storage/ftp.rb
@@ -77,7 +77,7 @@ module CarrierWave
         end
 
         def content_type
-          @content_type || file.content_type
+          @content_type || inferred_content_type
         end
 
         def content_type=(new_content_type)
@@ -93,6 +93,10 @@ module CarrierWave
         end
 
         private
+
+        def inferred_content_type
+          SanitizedFile.new(path).content_type
+        end
 
         def connection
           if @uploader.ftp_tls

--- a/lib/carrierwave/storage/sftp.rb
+++ b/lib/carrierwave/storage/sftp.rb
@@ -69,7 +69,7 @@ module CarrierWave
         end
 
         def content_type
-          @content_type || file.content_type
+          @content_type || inferred_content_type
         end
 
         def content_type=(new_content_type)
@@ -84,6 +84,10 @@ module CarrierWave
         end
 
         private
+
+        def inferred_content_type
+          SanitizedFile.new(path).content_type
+        end
 
         def use_ssl?
           @uploader.sftp_url.start_with?('https')

--- a/spec/ftp_file_spec.rb
+++ b/spec/ftp_file_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'carrierwave/storage/ftp'
+
+class FtpUploader < CarrierWave::Uploader::Base
+  storage :ftp
+end
+
+describe CarrierWave::Storage::FTP::File do
+  let(:uploader) do
+    Class.new(CarrierWave::Uploader::Base) do
+      storage :ftp
+    end.tap do |u|
+      allow(u).to receive(:store_path).and_return('uploads/test.jpg')
+    end
+  end
+
+  let(:base) { CarrierWave::Storage::FTP.new(uploader) }
+
+  let(:file) do
+    CarrierWave::Storage::FTP::File.new(uploader, base, uploader.store_path)
+  end
+
+  let(:mime_type) { double('mime_type') }
+
+  describe '#content_type' do
+    it 'delegates to base file by default' do
+      sanitized_file = CarrierWave::SanitizedFile.new(file)
+      expect(CarrierWave::SanitizedFile).to receive(:new).with(file.path).
+        and_return(sanitized_file)
+      expect(sanitized_file).to receive(:content_type).and_return(mime_type)
+
+      expect(file.content_type).to eq(mime_type)
+    end
+
+    it 'permits overriding the default value' do
+      file.content_type = mime_type
+
+      expect(file.content_type).to eq(mime_type)
+    end
+  end
+end

--- a/spec/ftp_file_spec.rb
+++ b/spec/ftp_file_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 require 'carrierwave/storage/ftp'
 
-class FtpUploader < CarrierWave::Uploader::Base
-  storage :ftp
-end
-
 describe CarrierWave::Storage::FTP::File do
   let(:uploader) do
     Class.new(CarrierWave::Uploader::Base) do

--- a/spec/ftp_spec.rb
+++ b/spec/ftp_spec.rb
@@ -140,8 +140,7 @@ describe CarrierWave::Storage::FTP do
     end
 
     it "returns the content_type of the file" do
-      @stored.should_receive(:file).and_return(Struct.new(:content_type).new('some/type'))
-      @stored.content_type.should == 'some/type'
+      @stored.content_type.should == 'image/jpeg'
     end
   end
 end

--- a/spec/sftp_file_spec.rb
+++ b/spec/sftp_file_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 require 'carrierwave/storage/sftp'
 
-class SftpUploader < CarrierWave::Uploader::Base
-  storage :sftp
-end
-
 describe CarrierWave::Storage::SFTP::File do
   let(:uploader) do
     Class.new(CarrierWave::Uploader::Base) do

--- a/spec/sftp_file_spec.rb
+++ b/spec/sftp_file_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'carrierwave/storage/sftp'
+
+class SftpUploader < CarrierWave::Uploader::Base
+  storage :sftp
+end
+
+describe CarrierWave::Storage::SFTP::File do
+  let(:uploader) do
+    Class.new(CarrierWave::Uploader::Base) do
+      storage :sftp
+    end.tap do |u|
+      allow(u).to receive(:store_path).and_return('uploads/test.jpg')
+    end
+  end
+
+  let(:base) { CarrierWave::Storage::SFTP.new(uploader) }
+
+  let(:file) do
+    CarrierWave::Storage::SFTP::File.new(uploader, base, uploader.store_path)
+  end
+
+  let(:mime_type) { double('mime_type') }
+
+  describe '#content_type' do
+    it 'delegates to base file by default' do
+      sanitized_file = CarrierWave::SanitizedFile.new(file)
+      expect(CarrierWave::SanitizedFile).to receive(:new).with(file.path).
+        and_return(sanitized_file)
+      expect(sanitized_file).to receive(:content_type).and_return(mime_type)
+
+      expect(file.content_type).to eq(mime_type)
+    end
+
+    it 'permits overriding the default value' do
+      file.content_type = mime_type
+
+      expect(file.content_type).to eq(mime_type)
+    end
+  end
+end

--- a/spec/sftp_spec.rb
+++ b/spec/sftp_spec.rb
@@ -102,8 +102,7 @@ describe CarrierWave::Storage::SFTP do
     end
 
     it "returns the content_type of the file" do
-      @stored.should_receive(:file).and_return(Struct.new(:content_type).new('some/type'))
-      @stored.content_type.should == 'some/type'
+      @stored.content_type.should == 'image/jpeg'
     end
   end
 end


### PR DESCRIPTION
Fixes:

```
     Failure/Error: expect(file.content_type).to eq(mime_type)
     NameError:
       undefined local variable or method `file' for #<CarrierWave::Storage::SFTP::File:0x0000000002ddc190>
     # ./lib/carrierwave/storage/sftp.rb:72:in `content_type'
```

and:

```
     Failure/Error: expect(file.content_type).to eq(mime_type)
     NameError:
       undefined local variable or method `file' for #<CarrierWave::Storage::FTP::File:0x0000000002833978>
     # ./lib/carrierwave/storage/ftp.rb:80:in `content_type'
```

Updates implementation to use the same content type inferrence behavior that is built into CarrierWave.