### PR TITLE
Updated required gems in the gemspec so it works with Ruby 3.2.1

### DIFF
--- a/carrierwave-ftp.gemspec
+++ b/carrierwave-ftp.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'carrierwave', ['>= 0.6.2']
   s.add_dependency 'double-bag-ftps', ['~> 0.1.4']
-  s.add_dependency 'net-sftp', ['~> 2.1.2']
+  s.add_dependency 'net-sftp', ['~> 4.0.0']
   s.add_development_dependency 'rake', ['~> 12.3']
   s.add_development_dependency 'rspec', ['~> 3.7']
   s.add_development_dependency 'rubocop', ['~> 0.52']

--- a/lib/carrierwave/storage/ftp.rb
+++ b/lib/carrierwave/storage/ftp.rb
@@ -76,7 +76,7 @@ module CarrierWave
           size
         end
 
-        def exist?
+        def exists?
           size ? true : false
         end
 

--- a/lib/carrierwave/storage/ftp.rb
+++ b/lib/carrierwave/storage/ftp.rb
@@ -76,7 +76,7 @@ module CarrierWave
           size
         end
 
-        def exists?
+        def exist?
           size ? true : false
         end
 

--- a/spec/ftp_spec.rb
+++ b/spec/ftp_spec.rb
@@ -108,7 +108,7 @@ describe CarrierWave::Storage::FTP do
 
     it 'checks whether a file exists' do
       expect(@stored).to receive(:size).and_return(10)
-      expect(@stored.exists?).to eq true
+      expect(@stored.exist?).to eq true
     end
 
     it 'returns the size of the file' do


### PR DESCRIPTION
The version of net-sftp used was causing this to break on the latest version of ruby because it relies on deprecated commands, have updated to the latest version.